### PR TITLE
Fix for #274.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Build on top of the following projects:
 ## Changelog
 
 ### **WORK IN PROGRESS**
-* (neopholus) Fixed #274 which was introduced in 3.4.1 enabling support for devices located in different subnets has been added. Possibly a breaking change for some people. 
+* (neopholus) Fixed #274 which was introduced in 3.4.0 enabling support for devices located in different subnets has been added. Possibly a breaking change for some people. 
 
 ### 3.4.1 (2024-07-02)
 * (foxriver76) migrated binary state to file

--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ Build on top of the following projects:
 * more testing
 
 ## Changelog
-<!--
-    ### **WORK IN PROGRESS**
--->
+
+### **WORK IN PROGRESS**
+* (neopholus) Fixed #274 which was introduced in 3.4.1 enabling support for devices located in different subnets has been added. Possibly a breaking change for some people. 
+
 ### 3.4.1 (2024-07-02)
 * (foxriver76) migrated binary state to file
 

--- a/lib/chromecastDevice.js
+++ b/lib/chromecastDevice.js
@@ -35,12 +35,14 @@ module.exports = async function (adapter, webPort) {
         static #knownDeviceIDs = [];
         
         // constructor
-        constructor(connection) {
+        constructor(connection, isManuallyAddedDevice) {
             this.shuffle = false;
             this.repeat = false;
 
             this._connection = connection;
             this._name = connection.name.replace(/[.\s]+/g, '_');
+
+            this._isManuallyAddedDevice = isManuallyAddedDevice;
 
             this.main()
                 .catch(e => adapter.log.error(`${this._name} - ${e}`));
@@ -50,29 +52,27 @@ module.exports = async function (adapter, webPort) {
             if (this._connection.type === 'Google Cast Group') {
                 this.id = `groups.${this._connection.id.replace(/-/g, '')}`;
             } else {
-                this.id = '';
-                try {
-                    // Read name that is defined in configuration (if any)
-                    this.id = this._connection.name;
-                    
-                    // for compatibility to version 3.0.3: replace whitespaces and dots with an underscore
-                    this.id = this.id.replace(/[.\s]+/g, '_');              
-                    
-                    // if somebody entered a MAC address, handle it like the result from getMac so that they look the same, i.e., remove colons
-                    this.id = this.id.replaceAll(':', '');
+                if (this._isManuallyAddedDevice) {
+                    // Device was manually added to the adapter config tab "devices" => the name defined there is used
+                    try {
+                        // Read name that is defined in configuration
+                        this.id = this._connection.name;
 
-                    // to avoid problems with identifiers, remove forbidden characters
-                    this.id = this.id.replace(adapter.FORBIDDEN_CHARS, '');                     
-                } catch (e) {
-                    // Some error while trying to read the name, ignore
-                }
-                // When we could not read a name defined in the configuration, we try to determine the MAC address.
-                if (this.id == '') {
+                        // for compatibility to version 3.0.3: replace whitespaces and dots with an underscore
+                        this.id = this.id.replace(/[.\s]+/g, '_');              
+                            
+                        // to avoid problems with identifiers, remove forbidden characters
+                        this.id = this.id.replace(adapter.FORBIDDEN_CHARS, '');                     
+                    } catch (e) {
+                        adapter.log.error(`${this._name} - Error in main() for "${this._connection.host}": ${e.toString()}`);
+                    }    
+                } else {
+                    // Device was not added manually, but was automatically datected => MAC address is used as name
                     try {
                         this.id = await getMac(this._connection.host);
                         this.id = this.id.replaceAll(':', '');
                     } catch (e) {
-                        adapter.log.error(`${this._name} - No name defined in configuration and cannot get MAC for "${this._connection.host}": ${e.toString()}`);
+                        adapter.log.error(`${this._name} - Cannot get MAC for "${this._connection.host}": ${e.toString()}`);
                     }
                 }
             }

--- a/main.js
+++ b/main.js
@@ -67,14 +67,14 @@ async function ready() {
             // Emulate registerForUpdates
             device.registerForUpdates = function () {};
 
-            devices.push(new ChromecastDevice(device));
+            devices.push(new ChromecastDevice(device, true));
         }
     }
 
     // var chromecastDevices = {};
     scanner = new Scanner(connection => {
         adapter.log.debug(`New connection: ${JSON.stringify(connection)}`);
-        devices.push(new ChromecastDevice(connection));
+        devices.push(new ChromecastDevice(connection, false));
     });
 
     // in this template all states changes inside the adapters namespace are subscribed


### PR DESCRIPTION
Now it is tracked whether a device comes from the configuration or from the auto discovery:
- Devices from the configuration are created using the name from the configuration as it was done before 3.0.3 introduced MAC addresses as names for devices that has been auto-discovered. Unfortunately, devices added to the device tab of the configuration broke with that, as also there MAC addresses would have been used as name and not the configured name. For devices in different subnets, the getMAC failed, of course.
- Devices from the auto discovery are using MAC address as name, as introduced with 3.0.3.
