### PR TITLE
Autofix: [Bug]: 

### DIFF
--- a/lib/chromecastDevice.js
+++ b/lib/chromecastDevice.js
@@ -1,3 +1,4 @@
+const debounce = require('lodash.debounce');
 'use strict';
 /* jshint esversion: 6 */
 /* jslint node: true */
@@ -30,6 +31,11 @@ module.exports = async function (adapter, webPort) {
         STOP: 2,
     };
 
+        // Debounce getStatus calls
+        this.debouncedGetStatus = debounce(this._mediaPlayer.getStatusPromise, 5000, {
+            leading: true,
+            trailing: false
+        });
     class ChromecastDevice {
         // List of all device ids already known to identify duplicates
         static #knownDeviceIDs = [];
@@ -786,7 +792,7 @@ module.exports = async function (adapter, webPort) {
                     JSON.stringify(cachedStatus.items));
             } else {
                 // Uncompleted status - trigger a new one - this happens after the playlist starts again
-                this._mediaPlayer && this._mediaPlayer.getStatusPromise().catch(err => adapter.log.error(`${this._name}- Cannot get status: ${err}`));
+                this._mediaPlayer && this.debouncedGetStatus().catch(err => adapter.log.error(`${this._name}- Cannot get status: ${err}`));
             }
 
             // Current Item ID

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@iobroker/adapter-core": "^3.2.2",
     "castv2-player": "^2.1.3",
     "node-arp": "^1.0.6",
+    "lodash.debounce": "^4.0.8",
     "youtube-remote": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Implement a debounce mechanism to limit how frequently getStatus is called for each device. This will prevent excessive status checks that can overload the system. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    